### PR TITLE
noted certificate format for Active Directory CAs

### DIFF
--- a/_includes/manuals/1.7/4.1.1_authentication.md
+++ b/_includes/manuals/1.7/4.1.1_authentication.md
@@ -24,6 +24,7 @@ This may use the variable `$login` which will be replaced by the login of the au
 #### Trusting SSL certificates
 
 When configuring an LDAPS connection, the certificate authority needs to be trusted.
+When using Active Directory Certificate Services, ensure to export the Enterprise PKI CA Certificate using the Base-64 encoded X.509 format. 
 
 On Red Hat based OSes:
 


### PR DESCRIPTION
DER encoded format does not work, and I did not test PKCS format
